### PR TITLE
Make graphs work again

### DIFF
--- a/ckanext/graph/db.py
+++ b/ckanext/graph/db.py
@@ -148,7 +148,7 @@ class ElasticSearchQuery(Query):
         field_type = utils.get_datastore_field_types()[self.date_field]
 
         if field_type == 'date':
-            histogram_options = {'field': f'data.{self.date_field}'}
+            histogram_options = {'field': f'data.{self.date_field}._d'}
         else:
             script = f"""try {{
               def parser = new SimpleDateFormat(\'yyyy-MM-dd\');

--- a/ckanext/graph/db.py
+++ b/ckanext/graph/db.py
@@ -187,12 +187,11 @@ class ElasticSearchQuery(Query):
         return query_stack
 
     def run(self):
-        data_dict = {
-            'resource_id': self.resource_id,
-            'search': self.query,
-            'raw_result': True,
-        }
-        results = toolkit.get_action('datastore_search_raw')({}, data_dict)
+        # the vds_multi_direct action is admin only to prevent misuse, but we know what
+        # we're doing, so skip the auth check
+        context = {'ignore_auth': True}
+        data_dict = {'resource_ids': [self.resource_id], 'search': self.query}
+        results = toolkit.get_action('vds_multi_direct')(context, data_dict)
         aggs = results['aggregations']
         extra_nesting = (
             self._is_date_query or len(self.filters) > 0 or self.q is not None

--- a/ckanext/graph/db.py
+++ b/ckanext/graph/db.py
@@ -159,7 +159,7 @@ class ElasticSearchQuery(Query):
              }}"""
             histogram_options = {'script': script}
 
-        histogram_options['interval'] = self.date_interval
+        histogram_options['calendar_interval'] = self.date_interval
 
         select_stack = self._nest(
             'aggs', self._bucket_name, 'date_histogram', histogram_options

--- a/ckanext/graph/lib/utils.py
+++ b/ckanext/graph/lib/utils.py
@@ -19,9 +19,7 @@ def get_datastore_field_types():
         'limit': 0,
     }
     results = toolkit.get_action('datastore_search')({}, data)
-    fields = results.get('raw_fields', results.get('fields', {}))
-
-    return {k: v.get('type', 'keyword') for k, v in fields.items()}
+    return {field['id']: field['type'] for field in results.get('fields', [])}
 
 
 def get_request_filters():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,29 +12,6 @@ class TestGetDatastoreFieldTypes(object):
     # that puts data in the datastore and then actually uses it for the test rather than completely
     # mocking it
 
-    def test_using_raw_fields(self):
-        resource_id = MagicMock()
-        search_results = {
-            'raw_fields': {
-                'field1': {'type': 'bert'},
-                'field2': {'type': 'flarp'},
-                'field3': {'keyword': 'banana'},
-            }
-        }
-
-        mock_toolkit = MagicMock(
-            c=MagicMock(resource=dict(id=resource_id)),
-            get_action=MagicMock(return_value=MagicMock(return_value=search_results)),
-        )
-
-        with patch('ckanext.graph.lib.utils.toolkit', mock_toolkit):
-            field_types = get_datastore_field_types()
-
-        assert len(field_types) == 3
-        assert field_types['field1'] == 'bert'
-        assert field_types['field2'] == 'flarp'
-        assert field_types['field3'] == 'keyword'
-
     def test_using_fields(self):
         resource_id = MagicMock()
         search_results = {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,11 +15,11 @@ class TestGetDatastoreFieldTypes(object):
     def test_using_fields(self):
         resource_id = MagicMock()
         search_results = {
-            'fields': {
-                'field1': {'type': 'bert'},
-                'field2': {'type': 'flarp'},
-                'field3': {'keyword': 'banana'},
-            }
+            'fields': [
+                {'id': 'field1', 'type': 'string'},
+                {'id': 'field2', 'type': 'number'},
+                {'id': 'field3', 'type': 'boolean'},
+            ]
         }
 
         mock_toolkit = MagicMock(
@@ -31,9 +31,9 @@ class TestGetDatastoreFieldTypes(object):
             field_types = get_datastore_field_types()
 
         assert len(field_types) == 3
-        assert field_types['field1'] == 'bert'
-        assert field_types['field2'] == 'flarp'
-        assert field_types['field3'] == 'keyword'
+        assert field_types['field1'] == 'string'
+        assert field_types['field2'] == 'number'
+        assert field_types['field3'] == 'boolean'
 
     def test_no_fields(self):
         resource_id = MagicMock()


### PR DESCRIPTION
Graphs stopped working since [ckanext-versioned-datastore v6](https://github.com/NaturalHistoryMuseum/ckanext-versioned-datastore/releases/tag/v6.0.0) due to various changes. This PR fixes but requires ckanext-versioned-datastore v6.1.0+ to work (see https://github.com/NaturalHistoryMuseum/ckanext-versioned-datastore/pull/186).

Fixes #36 